### PR TITLE
typo in install script

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -26,5 +26,5 @@ cd ~/carma_ws
 
 # Copy the installed files
 cd ~/carma_ws 
-cp -r install/ /opt/carma/install
+cp -r install/. /opt/carma/install
 chmod -R +x /opt/carma/install 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details

Fix for typo in docker install script. The missing period creates a new install folder instead of copying the contents of the install folder in the multi-stage docker build.

<!--- Describe your changes in detail -->

changed the copy command in docker/install.sh

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Building on Noetic is an intermediate step towards ROS2 Port.

## How Has This Been Tested?

Tested on Ubuntu 20.04.


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
