### PR TITLE
update checkout script to noetic/develop

### DIFF
--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -62,6 +62,9 @@ if [[ $COMPONENT_VERSION_STRING = "develop" ]]; then
         --build-arg VCS_REF=`git rev-parse --short HEAD` \
         --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` .
 else
+    #The addition of --network=host was a fix for a DNS resolution error that occured 
+    #when running the platform inside an Ubuntu 20.04 virtual machine. The error and possible soliutions are 
+    # discussed here: https://github.com/moby/moby/issues/41003
     docker build --network=host --no-cache -t $USERNAME/$IMAGE:$COMPONENT_VERSION_STRING \
         --build-arg VERSION="$COMPONENT_VERSION_STRING" \
         --build-arg VCS_REF=`git rev-parse --short HEAD` \

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -40,10 +40,17 @@ cd ${dir}/src
 
 # clone carma repos
 
-git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch noetic/develop
-git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch noetic/develop
-git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch noetic/develop
-git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch noetic/develop
+if [[ "$BRANCH" = "develop" ]]; then
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch noetic/develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch noetic/develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch noetic/develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch noetic/develop
+else
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch noetic/release
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch noetic/release
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch noetic/release
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch noetic/release
+fi
 
 # add astuff messages
 git clone https://github.com/astuff/astuff_sensor_msgs -b melodic

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -37,17 +37,13 @@ done
 
 cd ${dir}/src
 
-if [[ "$BRANCH" = "develop" ]]; then
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch develop
-      git clone --depth=1 https://github.com/mjeronimo/carma-utils.git --branch feature/ros-noetic-port
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch develop
-else
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch develop
-      git clone --depth=1 https://github.com/mjeronimo/carma-utils.git --branch feature/ros-noetic-port
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch develop
-fi
+
+# clone carma repos
+
+git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch noetic/develop
+git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch noetic/develop
+git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch noetic/develop
+git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch noetic/develop
 
 # add astuff messages
 git clone https://github.com/astuff/astuff_sensor_msgs -b melodic


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Update to docker/checkout.sh script to point to the correct  branches  when cloning carma repos. 

## Description

Changed branch from develop -> noetic/develop. Removed duplicate code. 

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Changes needed to reach parity with kinetic build.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Rebuilt docker images with the new script.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
